### PR TITLE
Allow higher versions of dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
   "license": "MIT",
   "require": {
     "php": ">=5.3.9",
-    "hafriedlander/phockito": "1.0.0",
-    "apache/log4php": "2.3.0",
-    "symfony/serializer": "2.7.3",
-    "symfony/property-access": "2.7.3"
+    "hafriedlander/phockito": "^1.0.0",
+    "apache/log4php": "^2.3.0",
+    "symfony/serializer": "^2.7.3",
+    "symfony/property-access": "^2.7.3"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
The dependencies are currently hardcoded to a specific patch release. They should allow any release prior to the next major.
