### PR TITLE
Only pause in GenerationUtils::pauseExecution if we need to.

### DIFF
--- a/src/main/php/com-realexpayments-remote-sdk/utils/GenerationUtils.php
+++ b/src/main/php/com-realexpayments-remote-sdk/utils/GenerationUtils.php
@@ -132,10 +132,15 @@ class GenerationUtils {
 
 	}
 
+	private static $lastCall;
+
 	private static function pauseExecution() {
-		// pause the execution for 100 milliseconds to avoid name collission
-		// in case many ids are generated in one go
-		usleep( 100000 );
+		if (self::$lastCall > microtime(TRUE) - 0.1) {
+			// pause the execution for 100 milliseconds to avoid name collission
+			// in case many ids are generated in one go
+			usleep( 100000 );
+		}
+		self::$lastCall = microtime(TRUE);
 	}
 
 }


### PR DESCRIPTION
A 100ms paud seconds is quite a long pause when you consider Google recommends [response times <200ms](https://developers.google.com/speed/docs/insights/Server).

We can skip the pause unless we are within 100ms of the last time we were called.
